### PR TITLE
Update demo for pac4j 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
     </repositories>
 
     <properties>
-        <pac4jVersion>5.1.4</pac4jVersion>
+        <pac4jVersion>6.0.0</pac4jVersion>
         <ratpackVersion>1.9.0</ratpackVersion>
-        <ratpackPac4jVersion>4.0.0-SNAPSHOT</ratpackPac4jVersion>
-        <java.version>11</java.version>
+        <ratpackPac4jVersion>5.0.0-SNAPSHOT</ratpackPac4jVersion>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <pac4jVersion>6.0.0</pac4jVersion>
-        <ratpackVersion>1.9.0</ratpackVersion>
+        <ratpackVersion>1.10.0-milestone-29</ratpackVersion>
         <ratpackPac4jVersion>5.0.0-SNAPSHOT</ratpackPac4jVersion>
         <java.version>17</java.version>
     </properties>
@@ -46,23 +46,6 @@
             <groupId>org.pac4j</groupId>
             <artifactId>ratpack-pac4j</artifactId>
             <version>${ratpackPac4jVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.5.4</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>io.ratpack</groupId>
-            <artifactId>ratpack-groovy</artifactId>
-            <version>${ratpackVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.ratpack</groupId>
@@ -149,7 +132,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.7</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -196,6 +179,9 @@
                         <version>3.0.0-M5</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/pac4j/demo/ratpack/RatpackPac4jDemo.java
+++ b/src/main/java/org/pac4j/demo/ratpack/RatpackPac4jDemo.java
@@ -1,7 +1,6 @@
 package org.pac4j.demo.ratpack;
 
 import static java.util.Collections.singletonMap;
-import static ratpack.groovy.Groovy.groovyTemplate;
 import static ratpack.handling.Handlers.redirect;
 
 import com.google.appengine.repackaged.com.google.common.collect.Maps;
@@ -41,177 +40,192 @@ import org.slf4j.LoggerFactory;
 import ratpack.error.ClientErrorHandler;
 import ratpack.error.ServerErrorHandler;
 import ratpack.func.Action;
-import ratpack.groovy.template.TextTemplateModule;
 import ratpack.guice.Guice;
 import ratpack.handling.Chain;
 import ratpack.pac4j.RatpackPac4j;
+import ratpack.render.Renderer;
 import ratpack.server.RatpackServer;
 import ratpack.session.SessionModule;
 import ratpack.session.SessionTypeFilter;
 
 public class RatpackPac4jDemo {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RatpackPac4jDemo.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RatpackPac4jDemo.class);
 
-    private static final String JWT_SALT = "12345678901234567890123456789012";
+  private static final String JWT_SALT = "12345678901234567890123456789012";
 
-    public static void main(final String[] args) throws Exception {
 
-        RatpackServer.start(server -> server
-                .serverConfig(c -> c.baseDir(new File("src/main").getAbsoluteFile()).port(8080))
-                .registry(Guice.registry(b -> b
-                        .bindInstance(ServerErrorHandler.class, (ctx, error) -> {
-                                LOGGER.error("Unexpected error", error);
-                                ctx.render(groovyTemplate("error500.html"));
-                            }
-                        )
-                        .bindInstance(ClientErrorHandler.class, (ctx, statusCode) -> {
-                            ctx.getResponse().status(statusCode);
-                            if (statusCode == 404) {
-                                ctx.render(groovyTemplate("error404.html"));
-                            } else if (statusCode == 401) {
-                                ctx.render(groovyTemplate("error401.html"));
-                            } else if (statusCode == 403) {
-                                ctx.render(groovyTemplate("error403.html"));
-                            } else {
-                                LOGGER.error("Unexpected: {}", statusCode);
-                            }
+  private static Template template(String name, Map<String, ?> model) {
+    return new Template(name, model);
+  }
+
+  private static Template template(String name) {
+    return new Template(name, Map.of());
+  }
+
+  public static void main(final String[] args) throws Exception {
+    RatpackServer.start(server -> server
+        .serverConfig(c -> c.baseDir(new File("src/main").getAbsoluteFile()).port(8080))
+        .registry(Guice.registry(b -> b
+            .bindInstance(ServerErrorHandler.class, (ctx, error) -> {
+                  LOGGER.error("Unexpected error", error);
+                  ctx.render(template("error500.html"));
+                }
+            )
+            .multiBind(Renderer.class, TemplateRenderer.class)
+            .bindInstance(ClientErrorHandler.class, (ctx, statusCode) -> {
+              ctx.getResponse().status(statusCode);
+              if (statusCode == 404) {
+                ctx.render(template("error404.html"));
+              } else if (statusCode == 401) {
+                ctx.render(template("error401.html"));
+              } else if (statusCode == 403) {
+                ctx.render(template("error403.html"));
+              } else {
+                LOGGER.error("Unexpected: {}", statusCode);
+              }
+            })
+            .module(SessionModule.class)
+            .module(new AbstractModule() {
+              @Override
+              protected void configure() {
+                binder().bind(SessionTypeFilter.class).toInstance(SessionTypeFilter.unsafeAllowAll());
+              }
+            })
+        ))
+        .handlers(chain -> {
+          final OidcConfiguration oidcConfig = new OidcConfiguration();
+          oidcConfig.setClientId("343992089165-sp0l1km383i8cbm2j5nn20kbk5dk8hor.apps.googleusercontent.com");
+          oidcConfig.setSecret("uR3D8ej1kIRPbqAFaxIE3HWh");
+          oidcConfig.setUseNonce(true);
+          oidcConfig.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
+          //oidcConfig.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
+          oidcConfig.addCustomParam("prompt", "consent");
+          final OidcClient oidcClient = new OidcClient(oidcConfig);
+          oidcClient.setAuthorizationGenerator((ctx, profile) -> {
+            profile.addRole("ROLE_ADMIN");
+            return Optional.of(profile);
+          });
+
+          final SAML2Configuration cfg = new SAML2Configuration("resource:samlKeystore.jks",
+              "pac4j-demo-passwd",
+              "pac4j-demo-passwd",
+              "resource:metadata-okta.xml");
+          cfg.setMaximumAuthenticationLifetime(3600);
+          cfg.setServiceProviderEntityId("http://localhost:8080/callback?client_name=SAML2Client");
+          cfg.setServiceProviderMetadataPath("sp-metadata-ratpack.xml");
+          final SAML2Client saml2Client = new SAML2Client(cfg);
+
+          final FacebookClient facebookClient = new FacebookClient("145278422258960",
+              "be21409ba8f39b5dae2a7de525484da8");
+          final TwitterClient twitterClient = new TwitterClient("CoxUiYwQOSFDReZYdjigBA",
+              "2kAzunH5Btc4gRSaMr7D7MkyoJ5u1VzbOOzE8rBofs");
+
+          // HTTP
+          final FormClient formClient = new FormClient("/loginForm.html",
+              new SimpleTestUsernamePasswordAuthenticator());
+          final IndirectBasicAuthClient basicAuthClient = new IndirectBasicAuthClient(
+              new SimpleTestUsernamePasswordAuthenticator());
+
+          // CAS
+          final CasClient casClient = new CasClient(new CasConfiguration("https://casserverpac4j.herokuapp.com/login"));
+
+          // direct clients
+          final SignatureConfiguration signatureConfiguration = new SecretSignatureConfiguration(JWT_SALT);
+          final EncryptionConfiguration encryptionConfiguration = new SecretEncryptionConfiguration(JWT_SALT);
+          final JwtAuthenticator jwtAuthenticator = new JwtAuthenticator(Arrays.asList(signatureConfiguration),
+              Arrays.asList(encryptionConfiguration));
+          final ParameterClient parameterClient = new ParameterClient("token", jwtAuthenticator);
+          parameterClient.setSupportGetRequest(true);
+          parameterClient.setSupportPostRequest(false);
+
+          // basic auth
+          final DirectBasicAuthClient directBasicAuthClient = new DirectBasicAuthClient(
+              new SimpleTestUsernamePasswordAuthenticator());
+
+          chain
+              .path(redirect(301, "index.html"))
+              .all(RatpackPac4j.authenticator("callback", formClient, saml2Client, facebookClient, twitterClient,
+                  basicAuthClient, casClient, oidcClient, parameterClient, directBasicAuthClient))
+              .prefix("facebook", auth(facebookClient.getName()))
+              .prefix("facebookadmin",
+                  auth(facebookClient.getName(), new RequireAnyRoleAuthorizer("ROLE_ADMIN")))
+              .prefix("facebookcustom", auth(facebookClient.getName(), new Authorizer() {
+                @Override
+                public boolean isAuthorized(WebContext context, SessionStore sessionStore,
+                    List<UserProfile> profiles) {
+                  if (profiles == null || profiles.size() == 0) {
+                    return false;
+                  }
+                  return StringUtils.startsWith(profiles.get(0).getId(), "jle");
+                }
+              }))
+              .prefix("twitter", auth(twitterClient.getName()))
+              .prefix("form", auth(formClient.getName()))
+              .prefix("basicauth", auth(basicAuthClient.getName()))
+              .prefix("cas", auth(casClient.getName()))
+              .prefix("saml2", auth(saml2Client.getName()))
+              .prefix("oidc", auth(oidcClient.getName()))
+              .prefix("dba", auth(directBasicAuthClient.getName()))
+              .prefix("rest-jwt", auth(parameterClient.getName()))
+              .path("jwt.html", ctx -> {
+                    final Map<String, Object> model = Maps.newHashMap();
+                    RatpackPac4j.userProfile(ctx)
+                        .route(Optional::isPresent, p -> {
+                          final JwtGenerator generator = new JwtGenerator(signatureConfiguration, encryptionConfiguration);
+                          final String token = generator.generate(p.get());
+                          model.put("token", token);
+                          ctx.render(template("jwt.html", model));
                         })
-                        .module(TextTemplateModule.class)
-                        .module(SessionModule.class)
-                    .module(new AbstractModule() {
-                        @Override
-                        protected void configure() {
-                            binder().bind(SessionTypeFilter.class).toInstance(SessionTypeFilter.unsafeAllowAll());
-                        }
-                    })
-                ))
-                .handlers(chain -> {
-                    final OidcConfiguration oidcConfig = new OidcConfiguration();
-                    oidcConfig.setClientId("343992089165-sp0l1km383i8cbm2j5nn20kbk5dk8hor.apps.googleusercontent.com");
-                    oidcConfig.setSecret("uR3D8ej1kIRPbqAFaxIE3HWh");
-                    oidcConfig.setUseNonce(true);
-                    oidcConfig.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
-                    //oidcConfig.setPreferredJwsAlgorithm(JWSAlgorithm.RS256);
-                    oidcConfig.addCustomParam("prompt", "consent");
-                    final OidcClient oidcClient = new OidcClient(oidcConfig);
-                  oidcClient.setAuthorizationGenerator((ctx, profile) -> {
-                        profile.addRole("ROLE_ADMIN");
-                        return Optional.of(profile);
-                    });
-
-                    final SAML2Configuration  cfg = new SAML2Configuration("resource:samlKeystore.jks",
-                        "pac4j-demo-passwd",
-                        "pac4j-demo-passwd",
-                        "resource:metadata-okta.xml");
-                    cfg.setMaximumAuthenticationLifetime(3600);
-                    cfg.setServiceProviderEntityId("http://localhost:8080/callback?client_name=SAML2Client");
-                    cfg.setServiceProviderMetadataPath("sp-metadata-ratpack.xml");
-                    final SAML2Client saml2Client = new SAML2Client(cfg);
-
-                    final FacebookClient facebookClient = new FacebookClient("145278422258960", "be21409ba8f39b5dae2a7de525484da8");
-                    final TwitterClient twitterClient = new TwitterClient("CoxUiYwQOSFDReZYdjigBA", "2kAzunH5Btc4gRSaMr7D7MkyoJ5u1VzbOOzE8rBofs");
-
-                    // HTTP
-                    final FormClient formClient = new FormClient("/loginForm.html", new SimpleTestUsernamePasswordAuthenticator());
-                    final IndirectBasicAuthClient basicAuthClient = new IndirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator());
-
-                    // CAS
-                    final CasClient casClient = new CasClient(new CasConfiguration("https://casserverpac4j.herokuapp.com/login"));
-
-                    // direct clients
-                    final SignatureConfiguration signatureConfiguration = new SecretSignatureConfiguration(JWT_SALT);
-                    final EncryptionConfiguration encryptionConfiguration = new SecretEncryptionConfiguration(JWT_SALT);
-                    final JwtAuthenticator jwtAuthenticator = new JwtAuthenticator(Arrays.asList(signatureConfiguration), Arrays.asList(encryptionConfiguration));
-                    final ParameterClient parameterClient = new ParameterClient("token", jwtAuthenticator);
-                    parameterClient.setSupportGetRequest(true);
-                    parameterClient.setSupportPostRequest(false);
-
-                    // basic auth
-                    final DirectBasicAuthClient directBasicAuthClient = new DirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator());
-
-                    chain
-                        .path(redirect(301, "index.html"))
-                        .all(RatpackPac4j.authenticator("callback", formClient, saml2Client, facebookClient, twitterClient, basicAuthClient, casClient, oidcClient, parameterClient, directBasicAuthClient))
-                        .prefix("facebook", auth(facebookClient.getName()))
-                        .prefix("facebookadmin",
-                            auth(facebookClient.getName(), new RequireAnyRoleAuthorizer("ROLE_ADMIN")))
-                        .prefix("facebookcustom", auth(facebookClient.getName(), new Authorizer() {
-                            @Override
-                            public boolean isAuthorized(WebContext context, SessionStore sessionStore,
-                                List<UserProfile> profiles) {
-                                if (profiles == null || profiles.size() == 0) {
-                                    return false;
-                                }
-                                return StringUtils.startsWith(profiles.get(0).getId(), "jle");
-                            }
-                        }))
-                        .prefix("twitter", auth(twitterClient.getName()))
-                        .prefix("form", auth(formClient.getName()))
-                        .prefix("basicauth", auth(basicAuthClient.getName()))
-                        .prefix("cas", auth(casClient.getName()))
-                        .prefix("saml2", auth(saml2Client.getName()))
-                        .prefix("oidc", auth(oidcClient.getName()))
-                        .prefix("dba", auth(directBasicAuthClient.getName()))
-                        .prefix("rest-jwt", auth(parameterClient.getName()))
-                        .path("jwt.html", ctx -> {
-                            final Map<String, Object> model = Maps.newHashMap();
-                            RatpackPac4j.userProfile(ctx)
-                                .route(Optional::isPresent, p -> {
-                                    final JwtGenerator generator = new JwtGenerator(signatureConfiguration, encryptionConfiguration);
-                                    final String token = generator.generate(p.get());
-                                    model.put("token", token);
-                                    ctx.render(groovyTemplate(model, "jwt.html"));
-                                })
-                                .then(p -> {
-                                    ctx.render(groovyTemplate(model, "jwt.html"));
-                                });
-                            }
-                        )
-                        .path("loginForm.html", ctx ->
-                            ctx.render(groovyTemplate(
-                                singletonMap("callbackUrl", formClient.getCallbackUrl() + "?client_name=FormClient"),
-                                "loginForm.html"
-                            ))
-                        )
-                        .path("logout.html", ctx ->
-                                RatpackPac4j.logout(ctx).then(() -> ctx.redirect("index.html"))
-                        )
-                        .path("index.html", ctx -> {
-                            LOGGER.debug("Retrieving user profile...");
-                            final Map<String, Object> model = Maps.newHashMap();
-                            RatpackPac4j.userProfile(ctx)
-                                .route(Optional::isPresent, p -> {
-                                    model.put("profile", p);
-                                    ctx.render(groovyTemplate(model, "index.html"));
-                                })
-                                .then(p -> {
-                                    ctx.render(groovyTemplate(model, "index.html"));
-                                });
+                        .then(p -> {
+                          ctx.render(template("jwt.html", model));
                         });
-                })
-        );
-    }
+                  }
+              )
+              .path("loginForm.html", ctx ->
+                  ctx.render(template(
+                      "loginForm.html",
+                      singletonMap("callbackUrl", formClient.getCallbackUrl() + "?client_name=FormClient")
+                  ))
+              )
+              .path("logout.html", ctx ->
+                  RatpackPac4j.logout(ctx).then(() -> ctx.redirect("index.html"))
+              )
+              .path("index.html", ctx -> {
+                LOGGER.debug("Retrieving user profile...");
+                final Map<String, Object> model = Maps.newHashMap();
+                RatpackPac4j.userProfile(ctx)
+                    .route(Optional::isPresent, p -> {
+                      model.put("profile", p);
+                      ctx.render(template("index.html", model));
+                    })
+                    .then(p -> {
+                      ctx.render(template("index.html", model));
+                    });
+              });
+        })
+    );
+  }
 
   private static Action<Chain> auth(String clientName) {
-        return chain -> chain
-            .all(RatpackPac4j.requireAuth(clientName))
-            .path("index.html", ctx ->
-                ctx.render(groovyTemplate(
-                    singletonMap("profile", ctx.get(UserProfile.class)),
-                    "protectedIndex.html"
-                ))
-            );
-    }
+    return chain -> chain
+        .all(RatpackPac4j.requireAuth(clientName))
+        .path("index.html", ctx ->
+            ctx.render(template(
+                "protectedIndex.html",
+                singletonMap("profile", ctx.get(UserProfile.class))
+            ))
+        );
+  }
 
   private static Action<Chain> auth(String clientName, Authorizer... authorizers) {
-        return chain -> chain
-            .all(RatpackPac4j.requireAuth(clientName, authorizers))
-            .path("index.html", ctx ->
-                ctx.render(groovyTemplate(
-                    singletonMap("profile", ctx.get(UserProfile.class)),
-                    "protectedIndex.html"
-                ))
-            );
-    }
+    return chain -> chain
+        .all(RatpackPac4j.requireAuth(clientName, authorizers))
+        .path("index.html", ctx ->
+            ctx.render(template(
+                "protectedIndex.html",
+                singletonMap("profile", ctx.get(UserProfile.class))
+            ))
+        );
+  }
 }

--- a/src/main/java/org/pac4j/demo/ratpack/Template.java
+++ b/src/main/java/org/pac4j/demo/ratpack/Template.java
@@ -1,0 +1,7 @@
+package org.pac4j.demo.ratpack;
+
+import java.util.Map;
+
+public record Template(String id, Map<String, ?> model) {
+
+}

--- a/src/main/java/org/pac4j/demo/ratpack/TemplateRenderer.java
+++ b/src/main/java/org/pac4j/demo/ratpack/TemplateRenderer.java
@@ -1,0 +1,36 @@
+package org.pac4j.demo.ratpack;
+
+import com.google.inject.Inject;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import ratpack.file.FileSystemBinding;
+import ratpack.handling.Context;
+import ratpack.render.Renderer;
+
+public class TemplateRenderer implements Renderer<Template> {
+
+  private static Pattern REGEX = Pattern.compile("\\$\\{model.(\\w+)}");
+
+  private final FileSystemBinding fileSystemBinding;
+
+  @Inject
+  TemplateRenderer(FileSystemBinding fileSystemBinding) {
+    this.fileSystemBinding = fileSystemBinding;
+  }
+
+  @Override
+  public Class<Template> getType() {
+    return Template.class;
+  }
+
+  @Override
+  public void render(Context context, Template template) throws Exception {
+    var file = context.get(FileSystemBinding.class).file("templates/" + template.id());
+    var text = Files.readString(file);
+    var templated = REGEX.matcher(text)
+        .replaceAll(m -> Optional.ofNullable(template.model().get(m.group(1))).map(Object::toString).orElse("null"));
+    context.getResponse().contentType("text/html");
+    context.getResponse().send(templated);
+  }
+}

--- a/src/test/java/org/pac4j/demo/ratpack/RatpackTest.java
+++ b/src/test/java/org/pac4j/demo/ratpack/RatpackTest.java
@@ -1,5 +1,9 @@
 package org.pac4j.demo.ratpack;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
+
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.junit.After;
 import org.junit.Test;
@@ -7,10 +11,6 @@ import ratpack.http.client.ReceivedResponse;
 import ratpack.test.CloseableApplicationUnderTest;
 import ratpack.test.MainClassApplicationUnderTest;
 import ratpack.test.http.TestHttpClient;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.containsString;
 
 public class RatpackTest {
 
@@ -46,7 +46,7 @@ public class RatpackTest {
             .params(m -> m.put("client_name", "FormClient"))
             .post("callback");
 
-        assertThat(response.getBody().getText(), containsString("attributes: {username=foo}"));
+        assertThat(response.getBody().getText(), containsString("attributes={username=foo}"));
         assertEquals(200, response.getStatusCode());
     }
 }


### PR DESCRIPTION
This updates the demo for the new version of ratpack-pac4j that supports pac4j 6.0.0.  The PR for that upgrade is here: https://github.com/pac4j/ratpack-pac4j/pull/14

Due to the Java 17 upgrade in pac4j 6.0.0, I had to remove the Groovy templating and replace it with a simple regex replace.

I'm not going to be terribly responsive over the holidays, so there's no rush.  @jthurne and @gcoopercos can cover some of the time for me.

I was not able to test the Okta login because the login info was rejected by Okta.